### PR TITLE
typo fixed, sending user id as response on login

### DIFF
--- a/app/controllers/login.js
+++ b/app/controllers/login.js
@@ -26,7 +26,8 @@ exports.login = async(req, res) => {
                             res.status(200).json({
                                 message: "login successful",
                                 token: token,
-                                role: "unverified"
+                                role: "unverified",
+                                userId: doc[0]._id
                             })
                         } else {
                             res.status(401).json({
@@ -54,7 +55,8 @@ exports.login = async(req, res) => {
                                         res.status(200).json({
                                             message: "login successful",
                                             token: token,
-                                            role: "student"
+                                            role: "student",
+                                            userId: document[0]._id
                                         })
                                     } else {
                                         res.status(401).json({
@@ -84,7 +86,8 @@ exports.login = async(req, res) => {
                                                     res.status(200).json({
                                                         message: "login successful",
                                                         token: token,
-                                                        role: "superuser"
+                                                        role: "superuser",
+                                                        userId: docs[0]._id
                                                     })
                                                 } else {
                                                     res.status(401).json({

--- a/app/controllers/profileVerification.js
+++ b/app/controllers/profileVerification.js
@@ -122,7 +122,7 @@ exports.reject = (req, res) => {
 }
 
 exports.deleteUnverifiedUserById = (req, res) => {
-    unverifiedProfiles.findByIdAndDelete({ _id: req.params.id })
+    UnverifiedProfiles.findByIdAndDelete({ _id: req.params.id })
         .then(doc => {
             res.status(200).json({
                 message: "successfully deleted",


### PR DESCRIPTION
The frontend team reported an error 500 for unverified user deletion API. A typo was discovered which is now fixed. Also resolved another minor issue. We are now sending the _id field of the user on successful login. This will make the frontend team's task easy to fetch info of logged-in users.